### PR TITLE
adopted FMLIST csv file for fmlist_scan integration

### DIFF
--- a/plugins/Scanner/scanner_server.js
+++ b/plugins/Scanner/scanner_server.js
@@ -1982,7 +1982,7 @@ function getLogFilePathCSV(date, time) {
     }
     
     // Determine the filename based on the isFiltered flag
-    const fileName = `SCANNER_${date}.csv`;
+    const fileName = `scan_${date}_fm_rds.csv`;
     
     // Create the full path to the file
     const filePath = path.join(logDir, fileName);

--- a/plugins/Scanner/scanner_server.js
+++ b/plugins/Scanner/scanner_server.js
@@ -1982,7 +1982,7 @@ function getLogFilePathCSV(date, time) {
     }
     
     // Determine the filename based on the isFiltered flag
-    const fileName = `scan_${date}_fm_rds.csv`;
+    const fileName = `scan_${date}T000000_TEF_fm_rds.csv`;
     
     // Create the full path to the file
     const filePath = path.join(logDir, fileName);

--- a/plugins/Scanner/scanner_server.js
+++ b/plugins/Scanner/scanner_server.js
@@ -2,7 +2,7 @@
 ///                                                         ///
 ///  SCANNER SERVER SCRIPT FOR FM-DX-WEBSERVER (V3.0 BETA8) ///
 ///                                                         ///
-///  by Highpoint               last update: 26.12.24       ///
+///  by Highpoint               last update: 27.12.24       ///
 ///  powered by PE5PVB                                      ///
 ///                                                         ///
 ///  https://github.com/Highpoint2000/webserver-scanner     ///
@@ -1997,12 +1997,7 @@ function getLogFilePathCSV(date, time) {
          // Update the header content as per your requirements
         let formattedServerDescription = ServerDescription.replace(/\n/g, '\\n'); // Ensure special characters in ServerDescription are handled properly 
 
-		// let header = `10,"highpoint2000@gmail.com"\n`;
-		// header += `11,"8032","HIGHP"\n`;
-		// header += `12,""\n`;
-		// header += `13,"public",""\n`;
-		// header += `14,"fixed"\n`;
-		// header += `15, 63, 47, 16\n`; 
+		let header = ``;  // no header needed anymore
        
         try {
             fs.writeFileSync(filePath, header, { flag: 'w' });
@@ -2084,7 +2079,7 @@ function writeCSVLogEntry(isFiltered) {
 	const OTHERPS = `""`;
 
     // Create the log entry line with the relevant data
-	let line = `${TYPE},${UNIXTIME},${FREQTEXT},${frequencyInHz},${rdson},${SNRMIN},${SNRAX},${dateTimeStringNanoSeconds},${GPSLAT},${GPSLON},${GPSMODE},${GPSALT},${GPSTIME},${PI},1,${PS},1,${TA},${TP},${MUSIC},${ProgramType},${GRP},${STEREO},${DYNPTY},${OTHERPI},${ALLPSTEXT},${OTHERPS}\n`;
+	let line = `${UNIXTIME},${FREQTEXT},${frequencyInHz},${rdson},${SNRMIN},${SNRAX},${dateTimeStringNanoSeconds},${GPSLAT},${GPSLON},${GPSMODE},${GPSALT},${GPSTIME},${PI},1,${PS},1,${TA},${TP},${MUSIC},${ProgramType},${GRP},${STEREO},${DYNPTY},${OTHERPI},,${ALLPSTEXT},${OTHERPS}\n`;
 	
     try {
         // Append the log entry to the CSV file


### PR DESCRIPTION
At least the file structure is valid in order to import it to FMLIST in section URDS, see my attempts in the screenshot. If you see an RDS logo, then the import was successful, see comment column.

Filename needs to have the format `scan_YYYY-MM-DDThhmmss_TEF_fm_rds.csv` (whereas the `_TEF_` is my proposal to distinguish from RTLSDR recordings). 000000 also works, but it not nice at the moment (hint: 00:00:00 will not work).

Hint: the path in line 303 needs to be changed for FMLIST scanner, it makes sense to define this path as a variable and include it to the config.

`const logDir = path.resolve(__dirname, '../../web/logs'); // Absoluter Pfad zum Log-Verzeichnis`

todos:

- GPS fix for Linux

![image](https://github.com/user-attachments/assets/5ca6a05c-3d82-43b5-9223-1bd440952d21)