### PR TITLE
Include antenna name in FMLIST log

### DIFF
--- a/plugins/Scanner/scanner.js
+++ b/plugins/Scanner/scanner.js
@@ -332,6 +332,7 @@ function handleWebSocketMessage(event) {
                 InfoFMLIST.includes("successful")
             ) {
                 sendToast('success important', 'Scanner', `${InfoFMLIST}`, false, false);
+                sendInitialWebSocketMessage(); // Restore Spectrum Graph ctx after FMLIST autolog
                 processingAllowed = false;
             } else if (
                 status === 'broadcast' &&
@@ -340,6 +341,7 @@ function handleWebSocketMessage(event) {
                 InfoFMLIST.includes("failed")
             ) {
                 sendToast('error important', 'Scanner', `${InfoFMLIST}`, false, false);
+                sendInitialWebSocketMessage(); // Restore Spectrum Graph ctx after FMLIST autolog
                 processingAllowed = false;
             } else if (status === 'broadcast' || status === 'send') {
                 updateDropdownValues(Sensitivity, ScannerMode, ScanHoldTime);


### PR DESCRIPTION
scanner.js - Restore Spectrum Graph ctx after FMLIST autolog

scanner_server.js  -
                  - Remember last antenna that was used (in addition to last frequency) before autoscan
                  - Include antenna name in FMLIST log if antenna switch is enabled
                  - Prevent Spectrum Graph socket spam if no antenna/signals detected
